### PR TITLE
Add startup probes and relax probe timings for CI stability

### DIFF
--- a/deployments/porch/2-function-runner.yaml
+++ b/deployments/porch/2-function-runner.yaml
@@ -67,12 +67,34 @@ spec:
             - containerPort: 9464
               name: metrics
           # Add grpc readiness probe to ensure the cache is ready
+          startupProbe:
+            exec:
+              command:
+                - /home/nonroot/grpc-health-probe
+                - -addr
+                - localhost:9445
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 30
           readinessProbe:
             exec:
               command:
                 - /home/nonroot/grpc-health-probe
                 - -addr
                 - localhost:9445
+            periodSeconds: 5
+            failureThreshold: 3
+            timeoutSeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - /home/nonroot/grpc-health-probe
+                - -addr
+                - localhost:9445
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+            timeoutSeconds: 5
           resources:
             requests:
               memory: "64Mi"

--- a/deployments/porch/3-porch-server.yaml
+++ b/deployments/porch/3-porch-server.yaml
@@ -94,13 +94,19 @@ spec:
             - --repo-operation-retry-attempts=3
             - --max-request-body-size=6291456 # Keep this in sync with function-runner's corresponding argument
             - --cache-type=db
-          #adding livenessProbes and readinessProbes for porch server
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 4443
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /healthz
               port: 4443
               scheme: HTTPS
-            initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 3
             successThreshold: 1
@@ -110,11 +116,10 @@ spec:
               path: /readyz
               port: 4443
               scheme: HTTPS
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            failureThreshold: 3
+            periodSeconds: 10
+            failureThreshold: 6
             successThreshold: 1
-            timeoutSeconds: 3                            
+            timeoutSeconds: 5                            
 ---
 apiVersion: v1
 kind: Service

--- a/deployments/porch/9-controllers.yaml
+++ b/deployments/porch/9-controllers.yaml
@@ -86,23 +86,29 @@ spec:
           limits:
             memory: 1Gi
             cpu: 1000m
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
             port: 8081
             scheme: HTTP
-          initialDelaySeconds: 30
           periodSeconds: 30
           successThreshold: 1
           timeoutSeconds: 5
         readinessProbe:
-          failureThreshold: 3
+          failureThreshold: 6
           httpGet:
             path: /readyz
             port: 8081
             scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 3            
+          timeoutSeconds: 5            


### PR DESCRIPTION
## Description
- What changed: Added `startupProbe` to porch-server, porch-controllers, and function-runner. Increased readiness probe `failureThreshold` and `periodSeconds`. Added missing `livenessProbe` to function-runner.
- Why it's needed: CI flakiness from pods being killed during slow startup when using `kpt live apply`.
- How it works: Startup probes gate liveness/readiness checks, giving containers up to ~155s to initialize before any kill decisions are made.

---

## Related Issue(s)
- N/A (CI flakiness observed in deploy pipeline)

---

## Type of Change
- [x] Bug fix
- [x] Enhancement

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [ ] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

---

## Testing Instructions (Optional)
1. Deploy to kind cluster with `make run-in-kind-v1alpha2`
2. Observe pods start without probe-related restarts
3. Run e2e tests to confirm no regressions

---

## Additional Notes (Optional)
- Postgres probes were already well-configured (startup probe with 300s budget) — left unchanged
- `.build/deploy/` copies also updated locally but are gitignored

---

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
  - Kiro to analyse existing probe configurations and generate relaxed timings with startup probes.
  - The author has fully verified all code.